### PR TITLE
Add link to reference data for "Reflectometry: Real life fitting" example

### DIFF
--- a/content/documentation/examples/fitting/extended/real-life-reflectometry/index.md
+++ b/content/documentation/examples/fitting/extended/real-life-reflectometry/index.md
@@ -28,3 +28,5 @@ Be patient, since it takes some time to run.
 
 {{< highlightfile file="/static/files/python/fitting/ex03_ExtendedExamples/specular/RealLifeReflectometryFitting.py" language="python" >}}
 
+{{% filelink file="/static/files/python/fitting/ex03_ExtendedExamples/specular/mg6a_Merged.txt.gz" name="Reference data" %}}
+


### PR DESCRIPTION
The link to the experimental data was missing, therefore the example could not be run