### PR TITLE
Installation docs including libcerf on macOS

### DIFF
--- a/content/documentation/installation/linux-detailed/first-simulation.md
+++ b/content/documentation/installation/linux-detailed/first-simulation.md
@@ -21,6 +21,18 @@ source <install_dir>/bin/thisbornagain.sh
 
 This command can also be placed in your `.bashrc` file (`.profile` for MacOS) to avoid having to run this command for each terminal session.
 
+{{< alert theme="info" >}}
+**Note for MacOS users**
+Additionally, `libcerf` needs to be manually downloaded and included in the BornAgain installation. 
+This is achieved with the following commands: 
+
+```bash
+wget http://apps.jcns.fz-juelich.de/src/MacLibs/cerf-1.14-Darwin.zip
+unzip cerf-1.14-Darwin.zip
+mv cerf-1.14-Darwin/lib/* /usr/local/lib/BornAgain-1.18/
+mv cerf-1.14-Darwin/include/* /usr/local/include/BornAgain-1.18/
+```
+
 #### Running the first Python simulation
 
 In your installation directory you will find the following directory structure:


### PR DESCRIPTION
I noticed during testing the installation on macOS from source that libcerf was not present what I tried to run the python interface. After speaking with Joachim, I realised that I need to get the libcerf code. The python interface appears to work with the code included as shown above.